### PR TITLE
Fixed editing issue with clicking outside modal

### DIFF
--- a/public/js/handleEventContainers.js
+++ b/public/js/handleEventContainers.js
@@ -522,10 +522,17 @@ document.addEventListener("DOMContentLoaded", () => {
 
   window.addEventListener("click", function (event) {
     if (event.target === addEventContainerModal) {
-      addEventContainerModal.style.display = "none";
+      //addEventContainerModal.style.display = "none";
+      closeAddEventContainerModal();
+      if (editing) {
+        editing = false;
+      }
     }
   });
   document.querySelector(".close").addEventListener("click", () => {
     closeAddEventContainerModal();
+    if (editing) {
+      editing = false;
+    }
   });
 });


### PR DESCRIPTION
Seems like this was fixed already.

Fixed another issue where when cancelling editing an event container by clicking the "x" or outside of the modal and then clicking the "add" button it would replace the old event container.

Fixes #87 